### PR TITLE
Add bit_fields_typed method

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,35 @@ s[:y] = 1
 p s[:a] # 64
 ```
 
+### Typed Bit Fields
+
+You can use the `bit_fields_typed` method to define bit fields with type information. This method accepts a hash where keys are field names and values are arrays containing `[width, type]`. For boolean fields (width of 1 with `:bool` type), it automatically generates a `?` helper method:
+
+```ruby
+class AccessFlags < FFI::BitStruct
+  layout \
+    :flags, :uint8
+
+  bit_fields_typed :flags,
+    revoked: [1, :bool],      # Creates revoked and revoked? methods
+    expired: [1, :bool],      # Creates expired and expired? methods
+    some_string: [4, :string], # Creates some_string method (no ? helper)
+    reserved: [2, :int]       # Creates reserved method (no ? helper)
+end
+
+flags = AccessFlags.new
+flags[:revoked] = 1
+flags[:expired] = 0
+
+p flags.revoked?  # => true
+p flags.expired?  # => false
+
+flags[:expired] = 1
+p flags.expired?  # => true
+```
+
+The `?` methods are only generated for fields that are 1 bit wide and have type `:bool`. Other field types can be used for documentation purposes and future functionality.
+
 ### Inspecting Bit Fields
 
 You can use the `bit_field_members` method to get a hash of bit fields grouped by parent field:

--- a/examples/typed_bit_fields_example.rb
+++ b/examples/typed_bit_fields_example.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative '../lib/ffi/bit_struct'
+
+# Example demonstrating the new bit_fields_typed method
+
+class AccessFlags < FFI::BitStruct
+  layout \
+    :flags, :uint8
+
+  # New typed syntax with automatic boolean helpers
+  bit_fields_typed :flags,
+    revoked: [1, :bool],      # Creates revoked and revoked? methods
+    expired: [1, :bool],      # Creates expired and expired? methods
+    some_string: [4, :string], # Just a regular field (4 bits wide)
+    reserved: [2, :int]       # Just a regular field (2 bits wide)
+end
+
+# Create instance
+flags = AccessFlags.new
+
+# Set boolean flags
+flags[:revoked] = 1
+flags[:expired] = 0
+flags[:some_string] = 15
+
+# Use the automatically generated "?" methods
+puts "Is revoked? #{flags.revoked?}"  # => true
+puts "Is expired? #{flags.expired?}"  # => false
+
+# Change values
+flags[:expired] = 1
+puts "Is expired now? #{flags.expired?}"  # => true
+
+# Access the underlying value
+puts "Raw flags value: #{flags[:flags]}"  # Shows the combined bit value
+
+# Note: Non-boolean or multi-bit fields don't get "?" methods
+# flags.some_string?  # This method doesn't exist
+puts "some_string value: #{flags[:some_string]}"  # => 15

--- a/test/typed_bit_fields_test.rb
+++ b/test/typed_bit_fields_test.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'ffi/bit_struct'
+
+class TypedBitFieldsTest < Minitest::Test
+  class TypedStruct < FFI::BitStruct
+    layout \
+      :flags, :uint8
+
+    bit_fields_typed :flags,
+      revoked: [1, :bool],
+      expired: [1, :bool],
+      some_string: [4, :string],
+      unused: [2, :int]
+  end
+
+  def test_boolean_field_getter
+    struct = TypedStruct.new
+    struct[:revoked] = 1
+    assert_equal 1, struct[:revoked]
+  end
+
+  def test_boolean_field_setter
+    struct = TypedStruct.new
+    struct[:expired] = 0
+    assert_equal 0, struct[:expired]
+  end
+
+  def test_revoked_question_method_exists
+    struct = TypedStruct.new
+    assert_respond_to struct, :revoked?
+  end
+
+  def test_expired_question_method_exists
+    struct = TypedStruct.new
+    assert_respond_to struct, :expired?
+  end
+
+  def test_revoked_question_method_returns_true
+    struct = TypedStruct.new
+    struct[:revoked] = 1
+    assert struct.revoked?
+  end
+
+  def test_revoked_question_method_returns_false
+    struct = TypedStruct.new
+    struct[:revoked] = 0
+    refute struct.revoked?
+  end
+
+  def test_expired_question_method_returns_true
+    struct = TypedStruct.new
+    struct[:expired] = 1
+    assert struct.expired?
+  end
+
+  def test_expired_question_method_returns_false
+    struct = TypedStruct.new
+    struct[:expired] = 0
+    refute struct.expired?
+  end
+
+  def test_non_boolean_field_no_question_method
+    struct = TypedStruct.new
+    refute_respond_to struct, :some_string?
+  end
+
+  def test_wider_non_boolean_field_no_question_method
+    struct = TypedStruct.new
+    refute_respond_to struct, :unused?
+  end
+
+  def test_some_string_field_getter
+    struct = TypedStruct.new
+    struct[:some_string] = 7
+    assert_equal 7, struct[:some_string]
+  end
+
+  def test_bit_field_hash_table_populated
+    expected = {
+      revoked: [:flags, 0, 1],
+      expired: [:flags, 1, 1],
+      some_string: [:flags, 2, 4],
+      unused: [:flags, 6, 2]
+    }
+    assert_equal expected, TypedStruct.instance_variable_get(:@bit_field_hash_table)
+  end
+
+  def test_bit_field_type_table_populated
+    expected = {
+      revoked: :bool,
+      expired: :bool,
+      some_string: :string,
+      unused: :int
+    }
+    assert_equal expected, TypedStruct.instance_variable_get(:@bit_field_type_table)
+  end
+
+  def test_multiple_boolean_fields_independent
+    struct = TypedStruct.new
+    struct[:revoked] = 1
+    struct[:expired] = 0
+
+    assert struct.revoked?
+    refute struct.expired?
+
+    struct[:expired] = 1
+    assert struct.expired?
+    assert struct.revoked?
+  end
+
+  def test_bit_field_members
+    expected = {
+      flags: %i[revoked expired some_string unused]
+    }
+    assert_equal expected, TypedStruct.bit_field_members
+  end
+
+  def test_bit_field_layout
+    expected = {
+      flags: {
+        revoked: { start: 0, width: 1 },
+        expired: { start: 1, width: 1 },
+        some_string: { start: 2, width: 4 },
+        unused: { start: 6, width: 2 }
+      }
+    }
+    assert_equal expected, TypedStruct.bit_field_layout
+  end
+end


### PR DESCRIPTION
This PR adds a `bit_fields_typed` method to define bit fields with type information. This method accepts a hash where keys are field names and values are arrays containing `[width, type]`. For boolean fields (width of 1 with `:bool` type), it automatically generates a `?` helper method.

```ruby
class AccessFlags < FFI::BitStruct
  layout \
    :flags, :uint8

  bit_fields_typed :flags,
    revoked: [1, :bool],      # Creates revoked and revoked? methods
    expired: [1, :bool],      # Creates expired and expired? methods
    some_string: [4, :string], # Creates some_string method (no ? helper)
    reserved: [2, :int]       # Creates reserved method (no ? helper)
end

flags = AccessFlags.new
flags[:revoked] = 1
flags[:expired] = 0

p flags.revoked?  # => true
p flags.expired?  # => false

flags[:expired] = 1
p flags.expired?  # => true
```

The `?` methods are only generated for fields that are 1 bit wide and have type `:bool`. Other field types can be used for documentation purposes and future functionality.

Generated via Claude 4.5.